### PR TITLE
Add some lines to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .DS_Store
-*.log
-.vscode
-reports
-env
-oss-output
-kubeconfig_*
 .envrc
+*.log
+.metals
+.vscode
+env
+kubeconfig
+kubeconfig_*
 node_modules/
+oss-output
+reports


### PR DESCRIPTION
Adds `kubeconfig` and some generated files to the root `.gitignore` file and reorders the the entries alphabetically.