### PR TITLE
Add dev and prod stack config files

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -1,0 +1,6 @@
+config:
+  zephyr-eks:desiredClusterSize: "3"
+  zephyr-eks:eksNodeInstanceType: t3.medium
+  zephyr-eks:maxClusterSize: "6"
+  zephyr-eks:minClusterSize: "3"
+  zephyr-eks:vpcNetworkCidr: 10.0.0.0/16

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -1,0 +1,6 @@
+config:
+  zephyr-eks:desiredClusterSize: "3"
+  zephyr-eks:eksNodeInstanceType: t3.medium
+  zephyr-eks:maxClusterSize: "6"
+  zephyr-eks:minClusterSize: "3"
+  zephyr-eks:vpcNetworkCidr: 10.0.0.0/16


### PR DESCRIPTION
Adds configuration files for the `dev` and `prod` stacks, using the same fallback settings as those used in the Pulumi program. Shouldn't be any functional difference for adding these -- just makes it easier to talk about stacks, configs, repos, etc., when there are actual files in the repo to refer to.