### PR TITLE
Fix ECR deletion

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -548,7 +548,9 @@ const uiLbService = new k8s.core.v1.Service("ui-lb-service", {
     },
 }, { provider: eksProvider });
 
-const repository = new awsx.ecr.Repository("repository");
+const repository = new awsx.ecr.Repository("repository", {
+    forceDelete: true,
+});
 
 // Create Deployments for the various application components
 const assetsDeployment = new k8s.apps.v1.Deployment("assets-deployment", {


### PR DESCRIPTION
Add forceDelete option to the ECR repository definition to fix problems deleting the ECR repository when running `pulumi destroy`.